### PR TITLE
Added a yaml to check if agent container has exited.

### DIFF
--- a/playbooks/restart_docker_engine_on_slaves.yml
+++ b/playbooks/restart_docker_engine_on_slaves.yml
@@ -1,0 +1,16 @@
+- hosts: kubernetes-slaves
+  tasks:
+   - name: check if agent container launched on agent or not
+     shell: docker ps -f status=exited,name=agent -q| wc -l
+     register: agent_container_count
+
+   - name: Restart docker engine if agent container not running
+     systemd:
+       state: restarted
+       name: docker
+     when:
+       - agent_container_count.stdout  != "0"
+
+   - name: Sleep 20 sec
+     pause:
+       seconds: 20


### PR DESCRIPTION
It is just a workaround to a problem where agent container exists just after provisioning
and restarting the docker solves the problem.